### PR TITLE
functions to get cron-jobs ht, pretty print jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Wait a minute to see output.
 
 Stop all jobs with `stop-cron`.
 
+To get the current jobs hash table: `(get-jobs)`.
+
+To pretty print current jobs: `(print-jobs)`.
+
 ## API
 
 ```lisp
@@ -67,6 +71,10 @@ start-cron
 restart-cron
 
 stop-cron
+
+get-jobs
+
+print-jobs
 ```
 
 Example:
@@ -96,6 +104,7 @@ https://40ants.com/lisp-project-of-the-day/2020/06/0087-cl-cron.html
 
 ## Changelog
 
+- 2026-06-13: add `(get-jobs)` and `(print-jobs)`.
 - 2026-06-12: the jobs hash-table is now `equalp` (names can be a string or anything else).
 - 2020-10-13: we added a name to the cl-cron thread.
 

--- a/cl-cron.lisp
+++ b/cl-cron.lisp
@@ -55,18 +55,16 @@
      (lambda (k v)
        (format stream "~%Job ~a:~%" k)
        (print-unreadable-object (v stream :type t)
-         (with-accessors ((min job-minute)
-                          (hour job-hour)
-                          (dom job-dom)
-                          (month job-month)
-                          (dow job-dow)
-                          (@boot job-@boot)
-                          (func job-func))
-             v
-           (format stream
-                   "Minute: ~a~%Hour: ~a~%Day of month: ~a\
+         (format stream
+                 "Minute: ~a~%Hour: ~a~%Day of month: ~a\
 Month: ~a~%Day of Week: ~a~%At-boot: ~a~%Function: ~a"
-                   min hour dom month dow @boot func)))
+                 (job-minute v)
+                 (job-hour v)
+                 (job-dom v)
+                 (job-month v)
+                 (job-dow v)
+                 (job-@boot v)
+                 (job-func v)))
        (format stream "~%"))
      *cron-jobs-hash*)))
 

--- a/cl-cron.lisp
+++ b/cl-cron.lisp
@@ -44,11 +44,11 @@
 (defvar *cron-jobs-hash* (make-hash-table :test #'equal)
   "Hash-table of all cron-job objects that need to be run.")
 
-(defun cron-jobs-get ()
+(defun get-jobs ()
   "Return the hash table of the current jobs."
   *cron-jobs-hash*)
 
-(defun cron-jobs-pretty-print (&optional (stream *standard-output*))
+(defun print-jobs (&optional (stream *standard-output*))
   "Print the current cron jobs to STREAM."
   (let ((*print-circle* t))
     (maphash

--- a/cl-cron.lisp
+++ b/cl-cron.lisp
@@ -37,9 +37,35 @@
             :documentation "Run the job only when start-cron is called.")
    (function-symbol :accessor job-func :initarg :job-func)))
 
+(defmethod print-object ((obj cron-job) stream)
+  (print-unreadable-object (obj stream :type t)
+    (with-accessors ((min job-minute)
+                     (hour job-hour)
+                     (dom job-dom)
+                     (month job-month)
+                     (dow job-dow)
+                     (@boot job-@boot)
+                     (func job-func))
+        obj
+      (format stream "Minute: ~a~%Hour: ~a~%Day of month: ~a~%Month: ~a\
+Day of Week: ~a~%At-boot: ~a~%Function: ~a"
+              min hour dom month dow @boot func))))
 
 (defvar *cron-jobs-hash* (make-hash-table :test #'equal)
   "Hash-table of all cron-job objects that need to be run.")
+
+(defun cron-jobs-get ()
+  "Return the hash table of the current jobs."
+  *cron-jobs-hash*)
+
+(defun cron-jobs-pretty-print (&optional (stream *standard-output*))
+  "Print the current cron jobs JOBS to STREAM."
+  (let ((*print-circle* t)
+        (*print-readably* t))
+    (maphash (lambda (k v)
+               (format stream "~%Job: ~a~%~a"
+                       (symbol-name k) v))
+             *cron-jobs-hash*)))
 
 (defvar *cron-dispatcher-thread* nil
   "The cron-dispatcher thread")

--- a/cl-cron.lisp
+++ b/cl-cron.lisp
@@ -37,19 +37,9 @@
             :documentation "Run the job only when start-cron is called.")
    (function-symbol :accessor job-func :initarg :job-func)))
 
-(defmethod print-object ((obj cron-job) stream)
-  (print-unreadable-object (obj stream :type t)
-    (with-accessors ((min job-minute)
-                     (hour job-hour)
-                     (dom job-dom)
-                     (month job-month)
-                     (dow job-dow)
-                     (@boot job-@boot)
-                     (func job-func))
-        obj
-      (format stream "Minute: ~a~%Hour: ~a~%Day of month: ~a~%Month: ~a\
-Day of Week: ~a~%At-boot: ~a~%Function: ~a"
-              min hour dom month dow @boot func))))
+;; default method:
+;; (defmethod print-object ((obj cron-job) stream)
+;;   (print-unreadable-object (obj stream :type t :identity t)))
 
 (defvar *cron-jobs-hash* (make-hash-table :test #'equal)
   "Hash-table of all cron-job objects that need to be run.")
@@ -59,13 +49,26 @@ Day of Week: ~a~%At-boot: ~a~%Function: ~a"
   *cron-jobs-hash*)
 
 (defun cron-jobs-pretty-print (&optional (stream *standard-output*))
-  "Print the current cron jobs JOBS to STREAM."
-  (let ((*print-circle* t)
-        (*print-readably* t))
-    (maphash (lambda (k v)
-               (format stream "~%Job: ~a~%~a"
-                       (symbol-name k) v))
-             *cron-jobs-hash*)))
+  "Print the current cron jobs to STREAM."
+  (let ((*print-circle* t))
+    (maphash
+     (lambda (k v)
+       (format stream "~%Job ~a:~%" (symbol-name k))
+       (print-unreadable-object (v stream :type t)
+         (with-accessors ((min job-minute)
+                          (hour job-hour)
+                          (dom job-dom)
+                          (month job-month)
+                          (dow job-dow)
+                          (@boot job-@boot)
+                          (func job-func))
+             v
+           (format stream
+                   "Minute: ~a~%Hour: ~a~%Day of month: ~a\
+Month: ~a~%Day of Week: ~a~%At-boot: ~a~%Function: ~a"
+                   min hour dom month dow @boot func)))
+       (format stream "~%"))
+     *cron-jobs-hash*)))
 
 (defvar *cron-dispatcher-thread* nil
   "The cron-dispatcher thread")

--- a/cl-cron.lisp
+++ b/cl-cron.lisp
@@ -53,7 +53,7 @@
   (let ((*print-circle* t))
     (maphash
      (lambda (k v)
-       (format stream "~%Job ~a:~%" (symbol-name k))
+       (format stream "~%Job ~a:~%" k)
        (print-unreadable-object (v stream :type t)
          (with-accessors ((min job-minute)
                           (hour job-hour)

--- a/packages.lisp
+++ b/packages.lisp
@@ -32,5 +32,5 @@
             #:log-cron-message
             #:*cron-log-file*
             #:*cron-load-file*
-            #:cron-jobs-pretty-print
-            #:cron-jobs-get))
+            #:print-jobs
+            #:get-jobs))

--- a/packages.lisp
+++ b/packages.lisp
@@ -21,14 +21,16 @@
 (defpackage :cl-cron
   (:nicknames :cron)
   (:use :cl)
-  (:export  :make-cron-job
-	    :delete-cron-job
-	    :start-cron
-	    :stop-cron
-	    :restart-cron
-	    :gen-list
-	    :min-list
-	    :max-list
-	    :log-cron-message
-	    :*cron-log-file*
-	    :*cron-load-file*))
+  (:export  #:make-cron-job
+            #:delete-cron-job
+            #:start-cron
+            #:stop-cron
+            #:restart-cron
+            #:gen-list
+            #:min-list
+            #:max-list
+            #:log-cron-message
+            #:*cron-log-file*
+            #:*cron-load-file*
+            #:cron-jobs-pretty-print
+            #:cron-jobs-get))


### PR DESCRIPTION
re: #6

- print-object for cron-jobs
- cron-jobs-get: return the cron-jobs hash table
- cron-jobs-pretty-print: pretty print the cron jobs
- export these two functions

this uses `print-object` to print the `cron-job` objects, which i suspect is not a good idea, as it is very verbose to always print that way. perhaps you have a suggestion vindarel?